### PR TITLE
chore(makefile): add makefile to build and run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+build: gcc -o stack stack.c
+run: chmod +r stack
+./stack


### PR DESCRIPTION
### Description
Abstract the following code into `build´ and `run` commands using Makefile:
```
gcc -o stack stack.c
chmod +r stack
./stack
```